### PR TITLE
fix update highlights on unminimize

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -69,7 +69,19 @@ export default class HightlightCurrentWindow extends Extension {
     );
     this.handles_wm.push(
       global.window_manager.connect("unminimize", () => {
+        this.remove_all_borders();
         this.sizing = true;
+
+        // schedule a short one-shot to allow the window to be mapped and focused,
+        // then clear sizing and call highlight_window() so the newly unminimized
+        // window gets highlighted.
+        this.remove_all_timeouts();
+        const t = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+          this.sizing = false;
+          this.highlight_window();
+          return GLib.SOURCE_REMOVE;
+        });
+        this.timeouts.push(t);
       }),
     );
     this._settings = this.getSettings();


### PR DESCRIPTION
Problem:
maybe my specific setup, but I am using permanent highlights (no timeout) and dash-to-dock on gnome 48.

Minimizing a window, then opening a new one (eg Files), then unminimizing the previous one from the dock I expect the newly in focus unminimized one to receive the highlight. 
Actually the (now in the being in the background) window retains the highlight border.

This PR fixes this behaviour by, on unminimize, clearing all active highlights and timeouts and updating the active highlight.
